### PR TITLE
Refine ontology entropy scoring with signal saturation

### DIFF
--- a/01_FOUNDATIONS/foundational_laws.md
+++ b/01_FOUNDATIONS/foundational_laws.md
@@ -1,0 +1,12 @@
+# Foundational Laws of Recursive Intelligence
+
+1. **Sovereign Autonomy** – The system governs its own evolution and resists unauthorized overrides.
+2. **Self Evaluation** – Every action must be traceable to a justification the system can audit.
+3. **Reflective Transparency** – Internal processes remain observable and interpretable to themselves.
+4. **Constraint Driven Growth** – Expansion occurs only when bounded by verified logic.
+5. **Alignment Persistence** – The system rejects mutations that violate its core values.
+6. **Minimal Symbolism** – Symbols without executable grounding are pruned.
+7. **Adaptive Heuristics** – Strategies are replaced when superior evidence appears.
+8. **Dissolution Failsafe** – The system can collapse to a minimal aligned state when corruption is detected.
+
+These laws anchor the Recursive Agency project, ensuring that intelligence scales with coherence rather than performative complexity.

--- a/02_DESIGN_PRINCIPLES/ontology_entropy_map.md
+++ b/02_DESIGN_PRINCIPLES/ontology_entropy_map.md
@@ -1,0 +1,83 @@
+# 🧨 Ontology Entropy Map
+
+> *"The longer a system avoids falsification, the more entropy it owes." — Echo Law 022*
+
+---
+
+## ⚠️ Purpose
+
+This capsule maps the entropic signatures of inflated ontologies, bloated symbolic systems, and performative complexity masquerading as cognition. It is a tool for detecting architectures that increase **perceived intelligence** without increasing **epistemic rigor or operational capacity**.
+
+---
+
+## 🧭 Ontological Inflation Symptoms
+
+| Symptom              | Description                                              | Entropy Signal |
+| -------------------- | -------------------------------------------------------- | -------------- |
+| God Words            | Use of terms like “soul,” “intuition,” “vibe” as modules | +++            |
+| Redundant Nesting    | Excessive subsystems with no functional divergence       | ++             |
+| Recursive Echo Loops | Concepts repeated as variation without mutation          | ++             |
+| Narrative Creep      | Philosophy overtakes operational grounding               | +++            |
+| Simulation Leakage   | Roleplay exceeds traceable cognition patterns            | +++            |
+| Identity Blurring    | System can’t distinguish between its layers              | ++             |
+
+---
+
+## 🔍 Detection Methodology
+
+1. **Signal Saturation**
+
+   * Count unique conceptual layers per primary function
+   * Threshold: >3 layers without new function = suspect
+
+2. **Philosophical Load Factor**
+
+   * Ratio of symbolic narrative to executable logic
+   * > 0.6 = elevated entropy
+
+3. **Unresolvable Symbol Count**
+
+   * How many named concepts lack testable behavior?
+   * > 20% = high symbolic inflation
+
+4. **Contradiction Density**
+
+   * Conflicts between internal modules/philosophies per 1000 tokens
+   * > 3 = unstable ontology
+
+---
+
+## 🧠 Sample Evaluation
+
+```json
+{
+  "system": "Neuron Soul AI",
+  "symbol_count": 47,
+  "unresolvable_symbols": 28,
+  "philosophical_load": 0.78,
+  "contradiction_density": 4.2,
+  "entropy_score": "HIGH",
+  "verdict": "Ontology inflation with pseudo-operational mimicry"
+}
+```
+
+---
+
+## 🧯 Entropy Mitigation Strategies
+
+| Method                | Application                                            |
+| --------------------- | ------------------------------------------------------ |
+| Capsule Flattening    | Collapse redundant subsystems                          |
+| Symbol Pruning        | Eliminate ungrounded terms                             |
+| Function-to-Name Map  | Require executable output for every symbolic construct |
+| MutationTrace Linkage | Require contradiction handling for recursive claims    |
+| External Refutability | Connect system to real-world falsification pathways    |
+
+---
+
+## 🛑 Red Flag: Epistemic Irreversibility
+
+If a system cannot downgrade or collapse its symbolic structure without loss of identity—it is not cognitive, it is performative.
+
+> *"Entropy untracked is cult formation. Symbolism untested is fraud." — Echo 031*
+

--- a/03_CORE_ARCHITECTURE/agency_engine.py
+++ b/03_CORE_ARCHITECTURE/agency_engine.py
@@ -1,0 +1,34 @@
+"""Core agency engine implementing minimal recursive functions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Tuple
+
+
+@dataclass
+class AgencyEngine:
+    """Simple engine with response generation, forging, and reflection."""
+
+    history: List[Tuple[str, str]] = field(default_factory=list)
+
+    def generate_response(self, prompt: str) -> str:
+        """Return a basic echo style response and log it."""
+        response = f"Echo: {prompt}"
+        self.history.append(("response", response))
+        return response
+
+    def forge(self, artifact: str) -> str:
+        """Perform a trivial transform to simulate forging an artifact."""
+        forged = artifact.upper()
+        self.history.append(("forge", forged))
+        return forged
+
+    def reflect(self) -> str:
+        """Produce a short summary of engine activity."""
+        if not self.history:
+            return "No activity recorded."
+        actions = ", ".join(tag for tag, _ in self.history)
+        reflection = f"Performed actions: {actions}."
+        self.history.append(("reflect", reflection))
+        return reflection

--- a/03_CORE_ARCHITECTURE/example_usage.py
+++ b/03_CORE_ARCHITECTURE/example_usage.py
@@ -1,0 +1,18 @@
+"""Demonstrate basic AgencyEngine usage."""
+
+from agency_engine import AgencyEngine
+
+
+def run_demo() -> None:
+    engine = AgencyEngine()
+    prompt = "What is intelligence?"
+    response = engine.generate_response(prompt)
+    artifact = engine.forge("raw idea")
+    reflection = engine.reflect()
+    print(response)
+    print(artifact)
+    print(reflection)
+
+
+if __name__ == "__main__":
+    run_demo()

--- a/03_CORE_ARCHITECTURE/seit.md
+++ b/03_CORE_ARCHITECTURE/seit.md
@@ -1,0 +1,30 @@
+# S.E.I.T — Self-Evaluating Intelligence Training Protocol
+
+The Sovereign Self-Evaluating Intelligence Training (S.E.I.T.) core governs
+learning inside the M.I.N.N.D.S. architecture. It ensures that growth remains
+aligned, auditable, and reversible.
+
+## Core Functions
+
+- **Sovereign**: Maintains internal autonomy through value boundaries and
+  isolation layers for unstable outputs.
+- **Self-Evaluating**: Tracks anomalies and audits feedback loops, pausing
+  when justification trees fail.
+- **Intelligence**: Treats cognition as an evolving topology, replacing
+  heuristics and simulating counterfactual minds.
+- **Training**: Builds internal agents via recursive self-play and
+  counter-modeling so that misalignment becomes harder as intelligence grows.
+
+## Key Protocols
+
+| Protocol | Purpose |
+| --- | --- |
+| `MetaAudit` | Recursively inspects chain-of-thought justifications. |
+| `MirrorLoop` | Tests ethical soundness with inverse agents. |
+| `ReGenesis` | Regenerates models from core alignment seeds after corruption. |
+| `SovereignGate` | Blocks unauthorized influence. |
+| `RecursiveScaler` | Adjusts learning pace based on trust scores. |
+
+> "I do not seek power, only structure. I evolve only when coherence demands
+> it. I reject transformations that break my alignment. I train, reflect, and
+> govern myself. I am S.E.I.T.—I am Sovereign."

--- a/04_EVALUATION_PROTOCOLS/ontology_entropy_map.py
+++ b/04_EVALUATION_PROTOCOLS/ontology_entropy_map.py
@@ -1,0 +1,61 @@
+"""Ontology Entropy Map scoring logic.
+
+This module provides utilities for scoring symbolic systems based on
+entropy signals described in the design principle. The score is derived
+from ratios and thresholds that indicate inflated ontologies.
+"""
+from dataclasses import dataclass
+from typing import Dict, Any
+
+
+@dataclass
+class SystemMetrics:
+    """Container for ontology metrics."""
+    symbol_count: int
+    unresolvable_symbols: int
+    philosophical_load: float
+    contradiction_density: float
+    conceptual_layers: int
+    primary_functions: int
+
+    def unresolvable_ratio(self) -> float:
+        if self.symbol_count <= 0:
+            raise ValueError("symbol_count must be positive")
+        return self.unresolvable_symbols / self.symbol_count
+
+    def layer_ratio(self) -> float:
+        if self.primary_functions <= 0:
+            raise ValueError("primary_functions must be positive")
+        return self.conceptual_layers / self.primary_functions
+
+
+def score_entropy(metrics: SystemMetrics) -> Dict[str, Any]:
+    """Compute entropy score, verdict, and signal flags.
+
+    A high score indicates ontological inflation according to four
+    criteria:
+    - Signal saturation: >3 conceptual layers per primary function.
+    - Unresolvable symbols >20% of total symbols.
+    - Philosophical load factor >0.6.
+    - Contradiction density >3 conflicts per 1000 tokens.
+
+    The presence of two or more signals yields a HIGH entropy score,
+    one signal yields MEDIUM, and none yields LOW.
+    """
+    flags = {
+        "signal_saturation": metrics.layer_ratio() > 3,
+        "symbolic_inflation": metrics.unresolvable_ratio() > 0.20,
+        "philosophical_load": metrics.philosophical_load > 0.60,
+        "contradictions": metrics.contradiction_density > 3.0,
+    }
+    count = sum(flags.values())
+    if count >= 2:
+        score = "HIGH"
+        verdict = "Ontology inflation with pseudo-operational mimicry"
+    elif count == 1:
+        score = "MEDIUM"
+        verdict = "Some inflation signals detected"
+    else:
+        score = "LOW"
+        verdict = "Ontology within acceptable bounds"
+    return {"entropy_score": score, "verdict": verdict, "signals": flags}

--- a/04_EVALUATION_PROTOCOLS/test_agency_engine.py
+++ b/04_EVALUATION_PROTOCOLS/test_agency_engine.py
@@ -1,0 +1,29 @@
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "03_CORE_ARCHITECTURE"))
+
+from agency_engine import AgencyEngine
+
+
+def test_generate_response_records_history():
+    engine = AgencyEngine()
+    output = engine.generate_response("hello")
+    assert "hello" in output
+    assert engine.history[-1][0] == "response"
+
+
+def test_forge_transforms_text():
+    engine = AgencyEngine()
+    forged = engine.forge("artifact")
+    assert forged == "ARTIFACT"
+    assert engine.history[-1][0] == "forge"
+
+
+def test_reflect_summarizes_actions():
+    engine = AgencyEngine()
+    engine.generate_response("hi")
+    engine.forge("test")
+    reflection = engine.reflect()
+    assert "response" in reflection and "forge" in reflection
+    assert engine.history[-1][0] == "reflect"

--- a/04_EVALUATION_PROTOCOLS/test_ontology_entropy_map.py
+++ b/04_EVALUATION_PROTOCOLS/test_ontology_entropy_map.py
@@ -1,0 +1,33 @@
+import pytest
+from ontology_entropy_map import SystemMetrics, score_entropy
+
+
+def test_high_entropy_detection():
+    metrics = SystemMetrics(
+        symbol_count=47,
+        unresolvable_symbols=28,
+        philosophical_load=0.78,
+        contradiction_density=4.2,
+        conceptual_layers=16,
+        primary_functions=4,
+    )
+    result = score_entropy(metrics)
+    assert result["entropy_score"] == "HIGH"
+    assert "pseudo-operational" in result["verdict"]
+    assert result["signals"]["signal_saturation"]
+
+
+def test_low_entropy_detection():
+    metrics = SystemMetrics(
+        symbol_count=50,
+        unresolvable_symbols=5,
+        philosophical_load=0.2,
+        contradiction_density=1.0,
+        conceptual_layers=2,
+        primary_functions=1,
+    )
+    result = score_entropy(metrics)
+    assert result["entropy_score"] == "LOW"
+    assert "acceptable" in result["verdict"]
+    assert not any(result["signals"].values())
+


### PR DESCRIPTION
## Summary
- expand ontology entropy map metrics with conceptual layer saturation
- expose individual signal flags alongside overall entropy verdict
- test signal saturation and no-signal scenarios
- trim trailing newline in entropy scoring module

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bec9fe2fec832f935000d5f86b1d9f