### PR TITLE
chore: remove unused pytest import

### DIFF
--- a/04_EVALUATION_PROTOCOLS/test_ontology_entropy_map.py
+++ b/04_EVALUATION_PROTOCOLS/test_ontology_entropy_map.py
@@ -1,4 +1,3 @@
-import pytest
 from ontology_entropy_map import SystemMetrics, score_entropy
 
 


### PR DESCRIPTION
## Summary
- clean up test by removing an unused pytest import

## Testing
- `ruff check 04_EVALUATION_PROTOCOLS/test_ontology_entropy_map.py`
- `pytest -q`
- `markdownlint '**/*.md'` *(fails: multiple style violations)*
- `yamllint .` *(fails: formatting errors)*
- `linkcheck README.md` *(fails: CLI usage error)*

------
https://chatgpt.com/codex/tasks/task_e_68bef9ba7c44832f81005dd0a41a7cd5