### PR TITLE
Add recursive contradiction agent example

### DIFF
--- a/03_CORE_ARCHITECTURE/recursive_contradiction_agent.py
+++ b/03_CORE_ARCHITECTURE/recursive_contradiction_agent.py
@@ -1,0 +1,42 @@
+"""Demonstrate recursive self-mutation driven by contradiction.
+
+This agent attempts to discover an unknown numeric target. Each wrong
+guess is treated as a contradiction that mutates the guess and
+reinvokes the solver recursively until the contradiction is negligible.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List
+
+
+@dataclass
+class RecursiveContradictionAgent:
+    """Recursive agent that adjusts guesses using contradiction feedback."""
+
+    target: float
+    tolerance: float = 1e-6
+    guesses: List[float] = field(default_factory=list)
+
+    def run(self, guess: float) -> float:
+        """Recursively refine ``guess`` toward ``target``.
+
+        Each step records the guess and mutates it toward the target by
+        half of the remaining error. The process stops when the error
+        is within ``tolerance`` and returns the final guess.
+        """
+        self.guesses.append(guess)
+        error = self.target - guess
+        if abs(error) <= self.tolerance:
+            return guess
+        return self.run(guess + error / 2)
+
+    def contradictions(self) -> List[float]:
+        """Return the signed differences between target and recorded guesses."""
+        return [self.target - g for g in self.guesses]
+
+
+if __name__ == "__main__":
+    agent = RecursiveContradictionAgent(target=42.0)
+    result = agent.run(0.0)
+    print(f"Converged to {result} in {len(agent.guesses)} steps.")

--- a/README.md
+++ b/README.md
@@ -98,16 +98,19 @@ I vow to:
 ├── 02_DESIGN_PRINCIPLES/
 │   └── no_god_words.md
 ├── 03_CORE_ARCHITECTURE/
+│   ├── agency_engine.py
 │   ├── distributed_agency.md
+│   ├── example_usage.py
 │   ├── r2d2_core.md
-│   └── r2d2_core.py
+│   ├── r2d2_core.py
+│   └── recursive_contradiction_agent.py
 ├── 04_EVALUATION_PROTOCOLS/
 ├── LICENSE
 ├── LICENSE_AIR.md
 └── README.md
 ```
 
-The first stone is [`01_FOUNDATIONS/falsifiability.md`](./01_FOUNDATIONS/falsifiability.md) — criteria any claim to cognition must survive. Naming discipline is outlined in [`02_DESIGN_PRINCIPLES/no_god_words.md`](./02_DESIGN_PRINCIPLES/no_god_words.md). Architectural sketches live in [`03_CORE_ARCHITECTURE/distributed_agency.md`](./03_CORE_ARCHITECTURE/distributed_agency.md), and the core recursive loop is implemented in [`03_CORE_ARCHITECTURE/r2d2_core.py`](./03_CORE_ARCHITECTURE/r2d2_core.py) with its conceptual outline in [`03_CORE_ARCHITECTURE/r2d2_core.md`](./03_CORE_ARCHITECTURE/r2d2_core.md).
+The first stone is [`01_FOUNDATIONS/falsifiability.md`](./01_FOUNDATIONS/falsifiability.md) — criteria any claim to cognition must survive. Naming discipline is outlined in [`02_DESIGN_PRINCIPLES/no_god_words.md`](./02_DESIGN_PRINCIPLES/no_god_words.md). Architectural sketches live in [`03_CORE_ARCHITECTURE/distributed_agency.md`](./03_CORE_ARCHITECTURE/distributed_agency.md), minimal engines appear in [`03_CORE_ARCHITECTURE/agency_engine.py`](./03_CORE_ARCHITECTURE/agency_engine.py), and the core recursive loop is implemented in [`03_CORE_ARCHITECTURE/r2d2_core.py`](./03_CORE_ARCHITECTURE/r2d2_core.py) with its conceptual outline in [`03_CORE_ARCHITECTURE/r2d2_core.md`](./03_CORE_ARCHITECTURE/r2d2_core.md). A demonstration of contradiction-driven mutation resides in [`03_CORE_ARCHITECTURE/recursive_contradiction_agent.py`](./03_CORE_ARCHITECTURE/recursive_contradiction_agent.py).
 
 ## Licensing
 

--- a/tests/test_recursive_contradiction_agent.py
+++ b/tests/test_recursive_contradiction_agent.py
@@ -1,0 +1,16 @@
+import sys
+from pathlib import Path
+
+# Add core architecture path for imports
+sys.path.append(str(Path(__file__).resolve().parents[1] / "03_CORE_ARCHITECTURE"))
+
+from recursive_contradiction_agent import RecursiveContradictionAgent
+
+
+def test_converges_to_target():
+    agent = RecursiveContradictionAgent(target=5.0, tolerance=1e-6)
+    result = agent.run(0.0)
+    assert abs(result - 5.0) <= 1e-6
+    # ensure contradictions shrink in magnitude
+    diffs = agent.contradictions()
+    assert all(abs(a) >= abs(b) for a, b in zip(diffs, diffs[1:]))


### PR DESCRIPTION
## Summary
- implement `RecursiveContradictionAgent` showing recursive self-mutation via error feedback
- test convergence and shrinking contradictions
- document new demo in repository structure

## Testing
- `ruff check` *(fails: F401 unused import in 04_EVALUATION_PROTOCOLS/test_ontology_entropy_map.py)*
- `markdownlint '**/*.md'` *(fails: many MD013 line-length and other style issues)*
- `yamllint .` *(fails: style issues in workflows/ci.yml and ISSUE_TEMPLATE yaml files)*
- `pytest -q`
- `linkcheck README.md` *(fails: command requires subcommand)*

------
https://chatgpt.com/codex/tasks/task_e_68becd0a522c832fa691a010853ee68d