### PR TITLE
Add tests for R2D2 solver and agency engine

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = tests

--- a/tests/test_agency_engine.py
+++ b/tests/test_agency_engine.py
@@ -1,0 +1,35 @@
+import pathlib
+import sys
+from typing import List, Tuple
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "03_CORE_ARCHITECTURE"))
+
+from agency_engine import AgencyEngine
+
+
+def test_generate_response_logs_history():
+    engine = AgencyEngine()
+    response = engine.generate_response("hello")
+    assert response == "Echo: hello"
+    assert engine.history == [("response", "Echo: hello")]
+
+
+def test_forge_transforms_text_and_logs():
+    engine = AgencyEngine()
+    forged = engine.forge("artifact")
+    assert forged == "ARTIFACT"
+    assert engine.history == [("forge", "ARTIFACT")]
+
+
+def test_reflect_summarizes_actions_and_tracks_history():
+    engine = AgencyEngine()
+    engine.generate_response("hi")
+    engine.forge("test")
+    reflection = engine.reflect()
+    assert reflection == "Performed actions: response, forge."
+    expected_history: List[Tuple[str, str]] = [
+        ("response", "Echo: hi"),
+        ("forge", "TEST"),
+        ("reflect", "Performed actions: response, forge."),
+    ]
+    assert engine.history == expected_history

--- a/tests/test_r2d2_solver.py
+++ b/tests/test_r2d2_solver.py
@@ -1,0 +1,63 @@
+import pathlib
+import sys
+from typing import List
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "03_CORE_ARCHITECTURE"))
+
+from r2d2_core import Capsule, R2D2Solver
+
+
+def make_solver() -> R2D2Solver:
+    """Create an R2D2Solver with deterministic toy hooks."""
+
+    def is_atomic(problem: object) -> bool:
+        return isinstance(problem, int)
+
+    def decompose(problem: List[int]) -> List[int]:
+        return problem
+
+    def hypothesize(problem: int, memory: List[Capsule]) -> List[int]:
+        return [problem + 1]
+
+    def mutate(hypothesis: int) -> List[int]:
+        return [hypothesis, hypothesis * 2]
+
+    def test(candidate: int) -> int:
+        return candidate
+
+    def score(observation: int) -> float:
+        return float(observation)
+
+    def aggregate(insights: List[int]) -> int:
+        return sum(insights)
+
+    def compress(insight: int | None, memory: List[Capsule]) -> Capsule:
+        value = 0 if insight is None else insight
+        return Capsule(insight=value, score=float(value))
+
+    return R2D2Solver(
+        is_atomic=is_atomic,
+        decompose=decompose,
+        hypothesize=hypothesize,
+        mutate=mutate,
+        test=test,
+        score=score,
+        aggregate=aggregate,
+        compress=compress,
+    )
+
+
+def test_solve_atomic_problem():
+    solver = make_solver()
+    memory: List[Capsule] = []
+    capsule = solver.solve(1, memory)
+    assert capsule.insight == 4
+    assert [c.insight for c in memory] == [4]
+
+
+def test_solve_composite_problem():
+    solver = make_solver()
+    memory: List[Capsule] = []
+    capsule = solver.solve([1, 2], memory)
+    assert capsule.insight == 10
+    assert [c.insight for c in memory] == [4, 6, 10]


### PR DESCRIPTION
## Summary
- add unit tests for R2D2Solver covering atomic and composite solving
- add unit tests for AgencyEngine with history tracking
- configure pytest to limit discovery to tests directory

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c157eb5f0c832fb88bcfb9b2a0a49d