### PR TITLE
Add basic R2D2 usage example

### DIFF
--- a/03_CORE_ARCHITECTURE/r2d2_core.md
+++ b/03_CORE_ARCHITECTURE/r2d2_core.md
@@ -42,3 +42,7 @@ while not solved:
 ```
 
 Each iteration sharpens the search space, with only new signal surviving.
+
+For a minimal working implementation that prints each capsule while solving a toy
+summation problem, see
+[`examples/basic_r2d2_usage.py`](../examples/basic_r2d2_usage.py).

--- a/README.md
+++ b/README.md
@@ -102,12 +102,15 @@ I vow to:
 │   ├── r2d2_core.md
 │   └── r2d2_core.py
 ├── 04_EVALUATION_PROTOCOLS/
+├── examples/
+│   └── basic_r2d2_usage.py
 ├── LICENSE
 ├── LICENSE_AIR.md
 └── README.md
 ```
 
 The first stone is [`01_FOUNDATIONS/falsifiability.md`](./01_FOUNDATIONS/falsifiability.md) — criteria any claim to cognition must survive. Naming discipline is outlined in [`02_DESIGN_PRINCIPLES/no_god_words.md`](./02_DESIGN_PRINCIPLES/no_god_words.md). Architectural sketches live in [`03_CORE_ARCHITECTURE/distributed_agency.md`](./03_CORE_ARCHITECTURE/distributed_agency.md), and the core recursive loop is implemented in [`03_CORE_ARCHITECTURE/r2d2_core.py`](./03_CORE_ARCHITECTURE/r2d2_core.py) with its conceptual outline in [`03_CORE_ARCHITECTURE/r2d2_core.md`](./03_CORE_ARCHITECTURE/r2d2_core.md).
+See [`examples/basic_r2d2_usage.py`](./examples/basic_r2d2_usage.py) for a minimal script that prints each capsule while summing a list.
 
 ## Licensing
 

--- a/examples/basic_r2d2_usage.py
+++ b/examples/basic_r2d2_usage.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+"""Minimal example of the R2D2 solver on a toy summation problem."""
+
+from pathlib import Path
+import sys
+from typing import Any, List
+
+# Add core module to path
+sys.path.append(str(Path(__file__).resolve().parents[1] / "03_CORE_ARCHITECTURE"))
+from r2d2_core import Capsule, R2D2Solver
+
+
+def is_atomic(problem: List[int]) -> bool:
+    """An atomic problem is a list with a single element."""
+    return len(problem) == 1
+
+
+def decompose(problem: List[int]) -> List[List[int]]:
+    """Split the list into two halves."""
+    mid = len(problem) // 2
+    return [problem[:mid], problem[mid:]]
+
+
+def hypothesize(problem: List[int], memory: List[Capsule]) -> List[int]:
+    """For an atomic list, the hypothesis is the contained value."""
+    return [problem[0]]
+
+
+def mutate(hypothesis: int) -> List[int]:
+    """No mutation; return the hypothesis unchanged."""
+    return [hypothesis]
+
+
+def test(candidate: int) -> int:
+    """Testing simply returns the candidate."""
+    return candidate
+
+
+def score(observation: int) -> float:
+    """Use the value itself as the score."""
+    return float(observation)
+
+
+def aggregate(results: List[int]) -> int:
+    """Combine sub-results by summing them."""
+    return sum(results)
+
+
+def compress(insight: Any, memory: List[Capsule]) -> Capsule:
+    """Wrap the insight in a capsule and print it."""
+    capsule = Capsule(insight=insight, score=float(insight or 0))
+    print(f"[Capsule] {capsule}")
+    return capsule
+
+
+def main() -> None:
+    numbers = [1, 2, 3, 4]
+    solver = R2D2Solver(
+        is_atomic=is_atomic,
+        decompose=decompose,
+        hypothesize=hypothesize,
+        mutate=mutate,
+        test=test,
+        score=score,
+        aggregate=aggregate,
+        compress=compress,
+    )
+    final = solver.solve(numbers)
+    print(f"Final result: {final.insight}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `examples/basic_r2d2_usage.py` showing minimal R2D2 hooks that sum a list and print each capsule
- reference the new example from `r2d2_core.md` and the repository `README`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c157f8dee4832f9c987a4b7b865055