### PR TITLE
Add gsutil upload helper

### DIFF
--- a/src/recursive_agency/__init__.py
+++ b/src/recursive_agency/__init__.py
@@ -2,5 +2,6 @@
 
 from .agency_engine import AgencyEngine
 from .r2d2_core import Capsule, R2D2Solver
+from .gcs_utils import upload_directory
 
-__all__ = ["AgencyEngine", "Capsule", "R2D2Solver"]
+__all__ = ["AgencyEngine", "Capsule", "R2D2Solver", "upload_directory"]

--- a/src/recursive_agency/gcs_utils.py
+++ b/src/recursive_agency/gcs_utils.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+"""Utility helpers for copying artifacts to Google Cloud Storage."""
+
+from pathlib import Path
+import subprocess
+
+
+def upload_directory(src: Path, bucket: str, prefix: str, use_shell: bool = False) -> None:
+    """Upload contents of ``src`` to ``gs://bucket/prefix/``.
+
+    ``gsutil`` expands globs only when executed through a shell. When
+    ``use_shell`` is false (default) each file is copied individually using
+    ``subprocess.run`` to avoid missing files. Setting ``use_shell`` to true
+    constructs a single ``gsutil -m cp`` command executed with ``shell=True``.
+    """
+    destination = f"gs://{bucket}/{prefix}/"
+    if use_shell:
+        # ``-m`` enables parallel uploads; ``shell=True`` allows wildcard
+        # expansion in the source path.
+        subprocess.run(
+            f"gsutil -m cp {src}/* {destination}", shell=True, check=True
+        )
+    else:
+        for path in src.glob("*"):
+            if path.is_file():
+                subprocess.run(["gsutil", "cp", str(path), destination], check=True)


### PR DESCRIPTION
## Summary
- add a utility to upload directories to GCS via gsutil
- expose upload helper through package init

## Testing
- `pytest -q`
- `make check` *(fails: markdownlint not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c16a766f74832fa467c75b500932ad