### PR TITLE
ci: skip guardian-bot commits

### DIFF
--- a/workflows/ci.yml
+++ b/workflows/ci.yml
@@ -1,13 +1,22 @@
+---
 name: ci
-on:
-  push: { branches: [main] }
-  pull_request: { branches: [main] }
+'on':
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
 jobs:
   build:
+    if: >-
+      ${{
+        github.actor != 'guardian-bot' &&
+        !contains(github.event.head_commit.message, 'chore(provenance)')
+      }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
-        with: { python-version: "3.11" }
+        with:
+          python-version: "3.11"
       - run: pip install ruff pytest markdown-link-check yamllint
       - run: make check


### PR DESCRIPTION
## Summary
- skip CI workflow when run by guardian-bot or provenance commits
- format workflow YAML for linting

## Testing
- `make check` *(fails: missing document start and comma spacing in ISSUE_TEMPLATE/contradiction.yaml)*

------
https://chatgpt.com/codex/tasks/task_e_68c16866cdb0832fb9a19dfa9f3c4f45