### PR TITLE
Fix gsutil upload helper to handle nested directories

### DIFF
--- a/src/recursive_agency/gcs_utils.py
+++ b/src/recursive_agency/gcs_utils.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """Utility helpers for copying artifacts to Google Cloud Storage."""
+
+from __future__ import annotations
 
 from pathlib import Path
 import subprocess
@@ -9,19 +9,25 @@ import subprocess
 def upload_directory(src: Path, bucket: str, prefix: str, use_shell: bool = False) -> None:
     """Upload contents of ``src`` to ``gs://bucket/prefix/``.
 
-    ``gsutil`` expands globs only when executed through a shell. When
+    The upload walks ``src`` recursively so that nested directories are also
+    copied. ``gsutil`` expands globs only when executed through a shell. When
     ``use_shell`` is false (default) each file is copied individually using
     ``subprocess.run`` to avoid missing files. Setting ``use_shell`` to true
-    constructs a single ``gsutil -m cp`` command executed with ``shell=True``.
+    constructs a single ``gsutil -m cp -r`` command executed with
+    ``shell=True``.
     """
     destination = f"gs://{bucket}/{prefix}/"
     if use_shell:
-        # ``-m`` enables parallel uploads; ``shell=True`` allows wildcard
-        # expansion in the source path.
+        # ``-m`` enables parallel uploads; ``-r`` copies recursively and
+        # ``shell=True`` allows wildcard expansion in the source path.
         subprocess.run(
-            f"gsutil -m cp {src}/* {destination}", shell=True, check=True
+            f"gsutil -m cp -r {src}/* {destination}", shell=True, check=True
         )
     else:
-        for path in src.glob("*"):
+        for path in src.rglob("*"):
             if path.is_file():
-                subprocess.run(["gsutil", "cp", str(path), destination], check=True)
+                rel = path.relative_to(src).as_posix()
+                subprocess.run(
+                    ["gsutil", "cp", str(path), f"{destination}{rel}"],
+                    check=True,
+                )

--- a/tests/test_gcs_utils.py
+++ b/tests/test_gcs_utils.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+from unittest.mock import patch, call
+import tempfile
+
+from recursive_agency.gcs_utils import upload_directory
+
+
+def test_upload_directory_recursively_uploads_files():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        root = Path(tmpdir)
+        (root / "root.txt").write_text("root")
+        nested = root / "nested"
+        nested.mkdir()
+        (nested / "child.txt").write_text("child")
+        with patch("recursive_agency.gcs_utils.subprocess.run") as run:
+            upload_directory(root, "bucket", "prefix", use_shell=False)
+            expected = [
+                call(
+                    ["gsutil", "cp", str(root / "root.txt"), "gs://bucket/prefix/root.txt"],
+                    check=True,
+                ),
+                call(
+                    [
+                        "gsutil",
+                        "cp",
+                        str(nested / "child.txt"),
+                        "gs://bucket/prefix/nested/child.txt",
+                    ],
+                    check=True,
+                ),
+            ]
+            assert run.call_args_list == expected
+
+
+def test_upload_directory_shell_recursive():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        root = Path(tmpdir)
+        with patch("recursive_agency.gcs_utils.subprocess.run") as run:
+            upload_directory(root, "bucket", "prefix", use_shell=True)
+            run.assert_called_once_with(
+                f"gsutil -m cp -r {root}/* gs://bucket/prefix/",
+                shell=True,
+                check=True,
+            )


### PR DESCRIPTION
## Summary
- make `upload_directory` recurse into subdirectories
- support recursive uploads in shell mode with `gsutil -m cp -r`
- add tests for recursive and shell upload behavior

## Testing
- `pytest -q`
- `make check` *(fails: yamllint reports errors in existing YAML files)*
- `ruff check src/recursive_agency/gcs_utils.py tests/test_gcs_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68c16f57e29c832f882b4cdf5dbb88b1