### PR TITLE
Clarify core solver packaging

### DIFF
--- a/src/recursive_agency/core.py
+++ b/src/recursive_agency/core.py
@@ -1,0 +1,19 @@
+"""Core solver primitives for recursive agency.
+
+This package-level module formalizes the experimental
+``03_CORE_ARCHITECTURE/r2d2_core.py`` prototype into a stable package
+component.  The original script offered quick iteration but mixed the
+algorithm with domain specifics.  By relocating the loop here we trade a
+bit of ad-hoc flexibility for a clearer API; callers must now provide hook
+implementations explicitly, which increases boilerplate for trivial cases
+but yields a predictable interface.
+
+The solver's behaviour is defined entirely by user-supplied hooks, so new
+hypothesis generators, scoring schemes, or memory backends can drop in
+without touching the recursion itself.  This pluggable design keeps the
+core minimal while supporting future extensions.
+"""
+
+from .r2d2_core import Capsule, R2D2Solver
+
+__all__ = ["Capsule", "R2D2Solver"]


### PR DESCRIPTION
## Summary
- Add `core.py` module to document migration of `r2d2_core.py` into the package
- Explain how the hook-based solver interface enables future extensions and note trade-offs of the refactor

## Testing
- `PYTHONPATH=src/recursive_agency pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c16f1f8824832fa15a8373410d54b0