### PR TITLE
chore: enforce commit Signed-off-by lines

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,6 @@
+#!/bin/sh
+# Ensure commit messages contain a Signed-off-by line.
+if ! grep -qi '^Signed-off-by:' "$1"; then
+  echo "Error: Commit message missing Signed-off-by line" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- add commit-msg hook that fails if a Signed-off-by line is missing

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68c16a6c79d0832fbc581714502de798