### PR TITLE
chore: enforce commit sign-off

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+if ! grep -iq '^Signed-off-by:' "$1"; then
+    echo "Error: Commit message must contain a Signed-off-by line." >&2
+    exit 1
+fi


### PR DESCRIPTION
## Summary
- require `Signed-off-by` in commit messages via commit-msg hook

## Testing
- `make test`
- `make lint` *(fails: yamllint errors in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68c16872f310832fa3bfb4033f437922