### PR TITLE
chore: enforce commit Signed-off-by lines

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -2,6 +2,9 @@
 
 We build by contradiction → reflection → revision. Read this before you open a PR.
 
+## Setup
+- `make hooks` → sets `.githooks` as the hooks path to enforce `Signed-off-by` lines.
+
 ## Ground rules
 - **License:** Code under **AGPLv3**. Docs under **CC BY-SA 4.0** (unless a file states otherwise).
 - **AIR Covenant:** Non-legal community commitment (see `/LICENSE_AIR.md`). We honor it; it does not replace AGPL.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: check lint test docs
+.PHONY: check lint test docs hooks
 
 check: lint test docs
 
@@ -12,3 +12,6 @@ test:
 
 docs:
 	@python -m linkcheck README.md || true
+
+hooks:
+	git config core.hooksPath .githooks


### PR DESCRIPTION
## Summary
- add commit-msg hook that fails if a Signed-off-by line is missing
- document how to enable hook via `make hooks`

## Testing
- `make check` (fails: `markdownlint` and `yamllint` missing; F401 unused import)
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68c1722158ec832f9a909b5b2f7423d7