### PR TITLE
chore(ci): skip guardian-bot runs

### DIFF
--- a/ISSUE_TEMPLATE/bug.yaml
+++ b/ISSUE_TEMPLATE/bug.yaml
@@ -1,3 +1,4 @@
+---
 name: Bug
 description: Broken behavior or spec deviation
 title: "[bug] "

--- a/ISSUE_TEMPLATE/contradiction.yaml
+++ b/ISSUE_TEMPLATE/contradiction.yaml
@@ -1,7 +1,8 @@
+---
 name: Contradiction
 description: Propose a mutation via contradiction
 title: "[contradiction] "
-labels: ["contradiction","design"]
+labels: ["contradiction", "design"]
 body:
   - type: textarea
     id: claim

--- a/workflows/ci.yml
+++ b/workflows/ci.yml
@@ -1,13 +1,22 @@
+---
 name: ci
-on:
-  push: { branches: [main] }
-  pull_request: { branches: [main] }
+'on':
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
 jobs:
   build:
+    if: >-
+      github.actor != 'guardian-bot' &&
+      !contains(github.event.head_commit.message, 'chore(provenance)')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
-        with: { python-version: "3.11" }
+        with:
+          python-version: "3.11"
       - run: pip install ruff pytest markdown-link-check yamllint
       - run: make check


### PR DESCRIPTION
## Summary
- avoid running CI for guardian-bot commits or provenance messages
- fix yaml formatting in issue templates

## Testing
- `make check`

------
https://chatgpt.com/codex/tasks/task_e_68c16a6f7e8c832f9f49fcb4bfee8c58