### PR TITLE
feat: add utility for uploading files to gcs

### DIFF
--- a/src/recursive_agency/__init__.py
+++ b/src/recursive_agency/__init__.py
@@ -2,5 +2,6 @@
 
 from .agency_engine import AgencyEngine
 from .r2d2_core import Capsule, R2D2Solver
+from .gcs_utils import upload_directory_to_gcs
 
-__all__ = ["AgencyEngine", "Capsule", "R2D2Solver"]
+__all__ = ["AgencyEngine", "Capsule", "R2D2Solver", "upload_directory_to_gcs"]

--- a/src/recursive_agency/gcs_utils.py
+++ b/src/recursive_agency/gcs_utils.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+"""Utilities for interacting with Google Cloud Storage via ``gsutil``."""
+
+from pathlib import Path
+import subprocess
+
+
+def upload_directory_to_gcs(src: Path, dst: str) -> None:
+    """Upload contents of ``src`` directory to ``dst`` on GCS.
+
+    The function iterates over all files produced by ``src.glob('*')`` and
+    uploads each one individually using ``gsutil cp``.  This avoids
+    wildcard-expansion issues that occur when passing patterns to
+    :func:`subprocess.run` without ``shell=True``.
+
+    Parameters
+    ----------
+    src:
+        Path to a local directory containing artifacts to upload.
+    dst:
+        Destination GCS URI (for example ``'gs://bucket/prefix/'``).
+    """
+    src = Path(src)
+    for path in src.glob('*'):
+        if path.is_file():
+            subprocess.run(["gsutil", "cp", str(path), dst], check=True)

--- a/tests/test_gcs_utils.py
+++ b/tests/test_gcs_utils.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+import subprocess
+from unittest import mock
+
+import pytest
+
+from recursive_agency.gcs_utils import upload_directory_to_gcs
+
+
+def test_upload_directory_invokes_gsutil_for_each_file(tmp_path, monkeypatch):
+    # create dummy files in the temp directory
+    first = tmp_path / "one.txt"
+    first.write_text("1")
+    second = tmp_path / "two.txt"
+    second.write_text("2")
+
+    calls = []
+
+    def fake_run(cmd, check):
+        calls.append((cmd, check))
+        return mock.Mock()
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    destination = "gs://bucket/prefix/"
+    upload_directory_to_gcs(tmp_path, destination)
+
+    assert len(calls) == 2
+    uploaded = {tuple(call[0]) for call in calls}
+    expected = {
+        ("gsutil", "cp", str(first), destination),
+        ("gsutil", "cp", str(second), destination),
+    }
+    assert uploaded == expected
+    assert all(call[1] is True for call in calls)


### PR DESCRIPTION
## Summary
- add `upload_directory_to_gcs` to iterate files and upload via `gsutil`
- export new utility from package root
- test uploading behavior to ensure each file triggers a separate `gsutil cp`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1684fee6c832f88306d58115ca1df