### PR TITLE
chore(ci): skip guardian-bot runs

### DIFF
--- a/workflows/ci.yml
+++ b/workflows/ci.yml
@@ -11,7 +11,8 @@ jobs:
   build:
     if: >-
       github.actor != 'guardian-bot' &&
-      !contains(github.event.head_commit.message, 'chore(provenance)')
+      (github.event_name != 'push' ||
+        !contains(github.event.head_commit.message, 'chore(provenance)'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- guard build job condition from missing head_commit on pull requests

## Testing
- `make check`


------
https://chatgpt.com/codex/tasks/task_e_68c1744f8474832f9418a97cb8fea9ad