### PR TITLE
Document R2D2 core integration

### DIFF
--- a/src/recursive_agency/__init__.py
+++ b/src/recursive_agency/__init__.py
@@ -1,6 +1,6 @@
 """Recursive Agency package."""
 
 from .agency_engine import AgencyEngine
-from .r2d2_core import Capsule, R2D2Solver
+from .core import Capsule, R2D2Solver
 
 __all__ = ["AgencyEngine", "Capsule", "R2D2Solver"]

--- a/src/recursive_agency/core.py
+++ b/src/recursive_agency/core.py
@@ -1,0 +1,19 @@
+"""Core solver interface for recursive problem solving.
+
+This module graduates the experimental prototype located at
+``03_CORE_ARCHITECTURE/r2d2_core.py`` into the package namespace.
+Wrapping the original R2D2 loop here exposes a stable API while
+retaining its hook-based design. Callers provide problem-specific
+functions for each stage—decomposition, hypothesis generation,
+mutation, testing, scoring, aggregation, and compression—so the solver
+remains domain agnostic.
+
+The shift trades the freedom of an ad hoc script for a committed
+interface. The lean surface keeps the core simple yet leaves ample
+room for future extensions such as alternative search heuristics or
+concurrency strategies without breaking existing users.
+"""
+
+from .r2d2_core import Capsule, R2D2Solver
+
+__all__ = ["Capsule", "R2D2Solver"]


### PR DESCRIPTION
## Summary
- Introduce `core.py` module with docstring explaining the evolution from the `r2d2_core` prototype and its extensible hook-based interface
- Update package init to re-export solver objects from the new core module

## Testing
- `ruff check src/recursive_agency/core.py src/recursive_agency/__init__.py`
- `pytest -q`
- `make check` *(fails: markdownlint, yamllint missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c1681cded0832fa8ae8574291e5618